### PR TITLE
Make sure python version 2.7 is used with yang explorer

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,9 @@ if [[ $NOVENV != 1 ]]; then
     if [ -f "v/bin/activate" ]; then
         source v/bin/activate
     else
-        virtualenv v
+	python_prog=$(type -a python2.7 | cut -d" " -f3)
+	echo "Using Python Program: ${python_prog}"
+        virtualenv --python=${python_prog} v
         source v/bin/activate
     fi
 fi


### PR DESCRIPTION
This commit allows folks to use yang explorer in environments where multiple python versions are installed by ensuring that only python version 2.7 is used inside the virtual environment.

This issue was reported as #64 