### PR TITLE
Generalize server host and port

### DIFF
--- a/server/static/YangExplorer.html
+++ b/server/static/YangExplorer.html
@@ -57,7 +57,7 @@
             // To use express install, set to playerProductInstall.swf, otherwise the empty string. 
             var xiSwfUrlStr = "expressInstall.swf";
             var flashvars = {};
-            flashvars.host = window.location.host.slice(0, window.location.host.indexOf(":"));
+            flashvars.host = window.location.hostname;
             flashvars.port = window.location.port;
             var params = {};
             params.quality = "high";

--- a/server/static/YangExplorer.html
+++ b/server/static/YangExplorer.html
@@ -57,6 +57,8 @@
             // To use express install, set to playerProductInstall.swf, otherwise the empty string. 
             var xiSwfUrlStr = "expressInstall.swf";
             var flashvars = {};
+            flashvars.host = window.location.host.slice(0, window.location.host.indexOf(":"));
+            flashvars.port = window.location.port;
             var params = {};
             params.quality = "high";
             params.bgcolor = "#ffffff";


### PR DESCRIPTION
Get yang-explorer host and port name from browser window so that no editing of YangExplorer.html is needed.