### PR TITLE
YDK script fixes for netconf operations, also fixes installation in env with multiple python2.7 installations

### DIFF
--- a/server/explorer/templates/ydkscript.py
+++ b/server/explorer/templates/ydkscript.py
@@ -61,25 +61,25 @@ def crud_get_config(crud_service, provider, ydk_obj):
     crud_service.read(provider, ydk_obj, only_config)
 {% endif %}
 {% if service_type == 'netconf' %}
-def netconf_create(netconf_service, provider, ydk_obj, 
-                   datastore=Datastore.candidate, default_operation=None, 
+def netconf_create(netconf_service, provider, datastore, ydk_obj,
+                   default_operation=None,
                    error_option=None, test_option=None):
     print('==============\NETCONF CREATE SERVICE\n==============')
 
-    netconf_service.edit_config(provider, ydk_obj, 
-                                datastore, default_operation, 
+    netconf_service.edit_config(provider, datastore, ydk_obj,
+                                default_operation,
                                 error_option, test_option)
 
-def netconf_replace(netconf_service, provider, ydk_obj,
-                   datastore=Datastore.candidate, default_operation=REPLACE,
-                   error_option=None, test_option=None):
+def netconf_replace(netconf_service, provider, datastore, ydk_obj,
+                    default_operation="replace",
+                    error_option=None, test_option=None):
     print('==============\nNETCONF REPLACE SERVICE\n==============')
 
-    netconf_service.edit_config(provider, ydk_obj, 
-                                datastore, default_operation, 
+    netconf_service.edit_config(provider, datastore, ydk_obj,
+                                default_operation,
                                 error_option, test_option)
 
-def netconf_delete(netconf_service, provider, datastore=Datastore.candidate):
+def netconf_delete(netconf_service, provider, datastore):
     print('==============\nNETCONF DELETE SERVICE\n==============')
 
     netconf_service.delete_config(provider, datastore)
@@ -90,8 +90,8 @@ def netconf_get(netconf_service, provider, ydk_obj,
 
     netconf_service.read(provider, ydk_obj, only_config)
 
-def netconf_get_config(netconf_service, provider, ydk_obj,
-                       datastore=Datastore.candidate, with_defaults_option=None):
+def netconf_get_config(netconf_service, provider, datastore, ydk_obj,
+                       with_defaults_option=None):
     print('==============\nNETCONF GET CONFIG SERVICE\n==============')
 
     netconf_service.get_config(provider, datastore, ydk_obj, with_defaults_option)
@@ -129,25 +129,25 @@ if __name__ == "__main__":
     {% endfor %}{% endif %}{% endif %}
 
     {% if service_type == 'netconf' %}netconf_service = NetconfService()
+    {% if datastore == 'candidate' %}datastore = Datastore.candidate
+    {% elif datastore == 'running' %}datastore = Datastore.running{% endif %}
     {% if service == 'create' %}{% for i in ydk_obj_names.split %}
     ydk_obj = {{i}}()
-    netconf_create(netconf_service, provider, ydk_obj)
-    {% endfor %}{% endif %}
-    {% if service == 'update' %}{% for i in ydk_obj_names.split %}
+    netconf_create(netconf_service, provider, datastore, ydk_obj)
+    {% endfor %}
+    {% elif service == 'update' %}{% for i in ydk_obj_names.split %}
     ydk_obj = {{i}}()
-    netconf_replace(netconf_service, provider, ydk_obj)
-    {% endfor %}{% endif %}
-    {% if service == 'delete' %}{% for i in ydk_obj_names.split %}
-    ydk_obj = {{i}}()
-    netconf_delete(netconf_service, provider, ydk_obj)
-    {% endfor %}{% endif %}
-    {% if service == 'get' %}{% for i in ydk_obj_names.split %}
+    netconf_replace(netconf_service, provider, datastore, ydk_obj)
+    {% endfor %}
+    {% elif service == 'delete' %}
+    netconf_delete(netconf_service, provider, datastore)
+    {% elif service == 'get' %}{% for i in ydk_obj_names.split %}
     ydk_obj = {{i}}()
     netconf_get(netconf_service, provider, ydk_obj)
-    {% endfor %}{% endif %}
-    {% if service == 'get_config' %}{% for i in ydk_obj_names.split %}
+    {% endfor %}
+    {% elif service == 'get_config' %}{% for i in ydk_obj_names.split %}
     ydk_obj = {{i}}()
-    netconf_get_config(netconf_service, provider, ydk_obj)
+    netconf_get_config(netconf_service, provider, datastore, ydk_obj)
     {% endfor %}{% endif %}{% endif %}
     {% endspaceless %}
 

--- a/server/explorer/utils/adapter.py
+++ b/server/explorer/utils/adapter.py
@@ -199,7 +199,7 @@ class Adapter(object):
         Generate YDK python script that uses Netconf provider and Netconf/CRUD services 
         """
 
-        logging.debug('gen_script: payload : \n' + payload)
+        logging.debug('gen_ydk_script: payload : \n' + payload)
 
         payload = payload.replace('<metadata>', '')
         payload = payload.replace('</metadata>', '')
@@ -207,25 +207,30 @@ class Adapter(object):
         _, device, fmt, lock, rpc = Adapter.parse_request(payload)
         if fmt == 'xpath' and rpc == '':
             request = ET.fromstring(payload)
-            logging.debug('gen_script: request etree string : \n' + 
+            logging.debug('gen_ydk_script: request etree string : \n' +
                           ET.tostring(request, pretty_print=True))
 
             rpc = Adapter._gen_rpc(username, request)
 
         if rpc is None:
-            logging.error('gen_script: Invalid RPC Generated')
+            logging.error('gen_ydk_script: Invalid RPC Generated')
             return None
 
-        logging.debug('gen_script: generated rpc : \n' + rpc)
+        logging.debug('gen_ydk_script: generated rpc : \n' + rpc)
 
         # currently we only support Netconf service provider and CRUD services
         parser = NetconfParser(rpc)
         op = parser.get_operation()
         datastore = parser.get_datastore()
 
+        if datastore == None:
+            datastore = ""
+
+        logging.error('gen_ydk_script: datastore : \n' + datastore)
+
         python_ydk_defs = ""
         for child in parser.get_data():
-            logging.debug('gen_script: child element : \n' + ET.tostring(child, pretty_print=True))
+            logging.debug('gen_ydk_script: child element : \n' + ET.tostring(child, pretty_print=True))
 
             # generate ydk script snippet for child element
             yam = YdkAppMaker(type='xml')

--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,7 @@ if [[ $NOVENV != 1 ]]; then
     if [ -f "v/bin/activate" ]; then
         source v/bin/activate
     else
-	python_prog=$(type -a python2.7 | cut -d" " -f3)
+	python_prog=$(type -a python2.7 | head -1 | cut -d" " -f3)
 	echo "Using Python Program: ${python_prog}"
         virtualenv --python=${python_prog} v
         source v/bin/activate


### PR DESCRIPTION
This fixes the generated YDK script for netconf create/get/get-config operations. Other operations such as delete/merge etc require parsing xc operations and so require a bit more work.

This also fixes installation of yang explorer in environments with multiple python2.7 installations.